### PR TITLE
Expose KituraOpenAPIConfig init

### DIFF
--- a/Sources/KituraOpenAPI/KituraOpenAPIConfig.swift
+++ b/Sources/KituraOpenAPI/KituraOpenAPIConfig.swift
@@ -20,4 +20,10 @@ public struct KituraOpenAPIConfig {
 
     // Path to serve SwaggerUI from. If nil, do not serve.
     public let swaggerUIPath: String?
+    
+    //Create KituraOpenAPIConfig
+    public init(apiPath: String? = nil, swaggerUIPath: String? = nil) {
+        self.apiPath = apiPath
+        self.swaggerUIPath = swaggerUIPath
+    }
 }

--- a/Sources/KituraOpenAPI/KituraOpenAPIConfig.swift
+++ b/Sources/KituraOpenAPI/KituraOpenAPIConfig.swift
@@ -21,8 +21,8 @@ public struct KituraOpenAPIConfig {
     // Path to serve SwaggerUI from. If nil, do not serve.
     public let swaggerUIPath: String?
     
-    //Create KituraOpenAPIConfig
-    public init(apiPath: String? = nil, swaggerUIPath: String? = nil) {
+    // Create KituraOpenAPIConfig
+    public init(apiPath: String?, swaggerUIPath: String?) {
         self.apiPath = apiPath
         self.swaggerUIPath = swaggerUIPath
     }


### PR DESCRIPTION
'KituraOpenAPIConfig' initializer was inaccessible due to 'internal' protection level.
Add public initializer which is accessible now.