### PR TITLE
Update directory search to "Kitura-OpenAPI"

### DIFF
--- a/Sources/KituraOpenAPI/Utils.swift
+++ b/Sources/KituraOpenAPI/Utils.swift
@@ -60,7 +60,7 @@ internal struct Utils {
     do {
       let dirContents = try fm.contentsOfDirectory(atPath: fm.currentDirectoryPath)
       for dir in dirContents {
-        if dir.contains("KituraOpenAPI") {
+        if dir.contains("Kitura-OpenAPI") {
           Log.verbose("Found Kitura-OpenAPI package directory")
           _ = fm.changeCurrentDirectoryPath(dir)
         }
@@ -68,7 +68,7 @@ internal struct Utils {
     } catch {
       Log.error("Error obtaining contents of directory: \(fm.currentDirectoryPath), \(error).")
     }
-
+    
     let packagePath = "\(fm.currentDirectoryPath)/Package.swift"
     if fm.fileExists(atPath: packagePath) {
       Log.verbose("Found Package.swift, returning \(fm.currentDirectoryPath)")


### PR DESCRIPTION
Currently it looks for directories containing the name `KituraOpenAPI` which is incorrect. It should be looking for the directory named `Kitura-OpenAPI`

This resolves the issue around KituraOpenAPI (the openapi/ui endpoint in particular) not working. 