### PR TITLE
Add dependency installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Add `KituraOpenAPI` to your target's dependencies:
 .target(name: "example", dependencies: ["KituraOpenAPI"]),
 ```
 
+Update your dependencies by running:
+```
+swift package update
+```
+
 Import the package inside your application:
 
 ```swift


### PR DESCRIPTION
Added the command line instructions for installing the OpenAPI dependency after adding it to your `Package.swift` file. 
