### PR TITLE
Correctly set Content-Type when serving OpenAPI definition

### DIFF
--- a/Sources/KituraOpenAPI/KituraOpenAPI.swift
+++ b/Sources/KituraOpenAPI/KituraOpenAPI.swift
@@ -54,7 +54,7 @@ public class KituraOpenAPI {
                 return
             }
 
-            response.headers.setType("application/json")
+            response.headers.setType("json")
             response.status(.OK)
             try response.send(json).end()
         }


### PR DESCRIPTION
Resolves #17 

The OpenAPI document serving endpoint attempted to set the `Content-Type` header to `application/json`, but the `response.headers.setType()` API appears to require just the specific media _subtype_, not the full media type.

The result is that the API sets a header with the appropriate type + subtype, in this case `application/json`, as intended.

(This could be considered a bug, and is certainly a usability issue - IMHO, setType should accept a fully qualified media type as well as the subtype).